### PR TITLE
Write roles as an array, not as a map

### DIFF
--- a/src/ShipType.cpp
+++ b/src/ShipType.cpp
@@ -193,8 +193,7 @@ ShipType::ShipType(const Id &_id, const std::string &path)
 	}
 
 	for (Json::iterator role = data["roles"].begin(); role != data["roles"].end(); ++role) {
-		const std::string rolename = role.key();
-		roles[rolename] = data["roles"].value(rolename, 0);
+		roles[*role] = true;
 	}
 
 	for (int it = 0; it < 4; it++)


### PR DESCRIPTION
Now you need to write roles in `data/ships/*.json` as:

```
roles : [
  "merchant",
  "mercenary",
  "pirate"
],

```
or

`roles : [ "merchant", "mercenary", "pirate" ],`

instead of

```
roles : {
  "merchant" : true,
  "mercenary" : true,
  "pirate": true
},
```

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

